### PR TITLE
add pagination and case insensitive search

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,9 +1,10 @@
 const Controller = {
+  initialPage: 1,
+
   search: (ev) => {
     ev.preventDefault();
-    const form = document.getElementById("form");
-    const data = Object.fromEntries(new FormData(form));
-    const response = fetch(`/search?q=${data.query}`).then((response) => {
+    const query = Controller.getQuery();
+    const response = fetch(`/search?q=${query}&pageSize=20&page=1`).then((response) => {
       response.json().then((results) => {
         Controller.updateTable(results);
       });
@@ -11,14 +12,33 @@ const Controller = {
   },
 
   updateTable: (results) => {
+    if (results.length === 0) return
     const table = document.getElementById("table-body");
-    const rows = [];
     for (let result of results) {
-      rows.push(`<tr><td>${result}</td></tr>`);
+      const newTaleRow = table.insertRow(-1);
+      const newCell = newTaleRow.insertCell(0);
+      newCell.innerText = result;
     }
-    table.innerHTML = rows;
   },
+
+  loadMore: (currentPage) => {
+    Controller.initialPage++;
+    const query = Controller.getQuery();
+    const response = fetch(`/search?q=${query}&pageSize=20&page=${Controller.initialPage}`).then((response) => {
+      response.json().then((results) => {
+        Controller.updateTable(results);
+      });
+    });
+  },
+
+  getQuery: () => {
+    const form = document.getElementById("form");
+    const data = Object.fromEntries(new FormData(form));
+    return data.query
+  }
 };
 
 const form = document.getElementById("form");
+const loadMore = document.getElementById("load-more");
 form.addEventListener("submit", Controller.search);
+loadMore.addEventListener("click", Controller.loadMore);

--- a/static/index.html
+++ b/static/index.html
@@ -21,7 +21,7 @@
     <tbody id="table-body"></tbody>
   </table>
   </p>
-  <button>Load More</button>
+  <button id="load-more">Load More</button>
   <script src="app.js"></script>
 </body>
 

--- a/test.js
+++ b/test.js
@@ -61,7 +61,6 @@ describe('ShakeSearch', () => {
     const initialResults = await page.evaluate(() => {
       const rows = document.querySelectorAll('#table-body tr');
         return Array.from(rows, row => row.textContent.trim());
-
     });
 
     await page.click('#load-more');
@@ -70,7 +69,6 @@ describe('ShakeSearch', () => {
     const updatedResults = await page.evaluate(() => {
       const rows = document.querySelectorAll('#table-body tr');
         return Array.from(rows, row => row.textContent.trim());
-
     });
 
     assert.isAbove(updatedResults.length, initialResults.length, 'More results should be added to the results table');


### PR DESCRIPTION
For this fix I wanted to keep things simple, since the idea it's to complete the whole task in about an hour.
I notice that there was 2 main problems with the code, the test were expecting that the APP have pagination and also can make a case-insensitive search on the Shakespeare work.

1. first I just change the `suffixarray` on the `Searcher` class, to store the data on lower case, and also modify the Search function to lower case the query, in this way we are able to compare lower case to lower case and still get into the front end the original text form the completeworks file.

2.I make the endpoint paginated, by adding 2 url parameters, the first one it's the page, that acts like an offset of the results, and a page size parameter, that is for setting how many results you want to see in the webpage.

3. once the endpoint was paginated, I add this behavior on the app.js file, since the `Load more` button didn't trigger any logic, so I write the code to handle the infinite scroll style fetching.